### PR TITLE
fix: Keep at top of pings

### DIFF
--- a/app/src/main/java/tech/relaycorp/ping/ui/common/DummyItemView.kt
+++ b/app/src/main/java/tech/relaycorp/ping/ui/common/DummyItemView.kt
@@ -1,0 +1,24 @@
+package tech.relaycorp.ping.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import com.airbnb.epoxy.ModelView
+
+@ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT, fullSpan = true)
+class DummyItemView
+@JvmOverloads
+constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    // 1 invisible px square
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(
+            MeasureSpec.makeMeasureSpec(1, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(1, MeasureSpec.EXACTLY)
+        )
+    }
+}

--- a/app/src/main/java/tech/relaycorp/ping/ui/main/MainActivity.kt
+++ b/app/src/main/java/tech/relaycorp/ping/ui/main/MainActivity.kt
@@ -14,6 +14,7 @@ import tech.relaycorp.ping.R
 import tech.relaycorp.ping.common.di.ViewModelFactory
 import tech.relaycorp.ping.domain.model.Ping
 import tech.relaycorp.ping.ui.BaseActivity
+import tech.relaycorp.ping.ui.common.dummyItemView
 import tech.relaycorp.ping.ui.peers.PeersActivity
 import tech.relaycorp.ping.ui.ping.SendPingActivity
 import javax.inject.Inject
@@ -60,6 +61,10 @@ class MainActivity : BaseActivity() {
 
     private fun updateList(pings: List<Ping>) {
         list.withModels {
+            dummyItemView {
+                id("top")
+            }
+
             pings.forEach { ping ->
                 pingItemView {
                     id(ping.pingId)


### PR DESCRIPTION
Fixes #25

If already at the top of the list of pings, when a new ping is added, it keeps being at the top of the list, to ensure the new ping is visible. But it won't show it if you were not at the top (this is usually the expected behaviour).