### PR TITLE
fix: Disable desugaring to work around bug in Android Gradle Plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,9 @@ android {
         }
     }
     compileOptions {
-        coreLibraryDesugaringEnabled true
+        // Workaround for https://github.com/relaycorp/awala-ping-android/issues/39
+        // coreLibraryDesugaringEnabled true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "tech.relaycorp.ping"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode 2
         versionName "0.2"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         applicationId "tech.relaycorp.ping"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 2
         versionName "0.2"

--- a/app/firebase-test-lab.yml
+++ b/app/firebase-test-lab.yml
@@ -4,17 +4,18 @@ spec:
   test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
   timeout: 30m
   device:
-    # Asus Nexus 7 (physical). The oldest device we're testing.
-    - model: flo
-      version: 21   # Android 5.0
-      locale: en
-      orientation: portrait
-
-    # Nexus 5X (virtual)
-    - model: Nexus5X
-      version: 24   # Android 7.0
-      locale: en
-      orientation: portrait
+# TODO: Test on Android API < 26 once we restore support for it.
+#    # Asus Nexus 7 (physical). The oldest device we're testing.
+#    - model: flo
+#      version: 21   # Android 5.0
+#      locale: en
+#      orientation: portrait
+#
+#    # Nexus 5X (virtual)
+#    - model: Nexus5X
+#      version: 24   # Android 7.0
+#      locale: en
+#      orientation: portrait
 
     # Nexus 5X (virtual)
     - model: Nexus5X

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -10,4 +10,7 @@
     <issue id="SelectableText" severity="ignore" />
     <issue id="UnusedIds" severity="informational" />
     <issue id="UnusedResources" severity="informational" />
+
+    <!-- TODO: Remove once we restore support for Android API < 26 -->
+    <issue id="ObsoleteSdkInt" severity="informational" />
 </lint>


### PR DESCRIPTION
Fixes #39.

TODO

- [x] Update awaladroid to require Android API 26+.
- [x] Update Android codelab to require Android API 26+.
- [x] Create issue in awaladroid to restore Android API 21-25 support.