### PR TITLE
fix: Allow flaky UI tests to pass in 3 attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Built application files
 *.apk
 *.ap_
+app/release/
 
 # Files for the ART/Dalvik VM
 *.dex

--- a/app/src/androidTest/java/tech/relaycorp/ping/test/IntentsRule.kt
+++ b/app/src/androidTest/java/tech/relaycorp/ping/test/IntentsRule.kt
@@ -16,7 +16,11 @@ class IntentsRule : TestRule {
                     // Occasionally `Intents.init()` might be called twice before `Intents.release()` is called
                 }
                 base.evaluate()
-                Intents.release()
+                try {
+                    Intents.release()
+                } catch (_: IllegalStateException) {
+                    // Occasionally `Intents.init()` might be missed
+                }
             }
         }
 }

--- a/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/AddPublicPeerActivityTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/AddPublicPeerActivityTest.kt
@@ -10,9 +10,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
+import com.schibsted.spain.barista.rule.flaky.AllowFlaky
+import com.schibsted.spain.barista.rule.flaky.FlakyTestRule
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import tech.relaycorp.ping.R
 import tech.relaycorp.ping.test.ActivityAssertions.waitForCurrentActivityToBe
@@ -26,6 +29,11 @@ class AddPublicPeerActivityTest {
     @Rule
     @JvmField
     val testRule = BaseActivityTestRule(PeersActivity::class, false)
+
+    @Rule
+    @JvmField
+    val flakyChainRule = RuleChain.outerRule(FlakyTestRule())
+        .around(testRule)
 
     @Before
     fun setUp() {
@@ -59,6 +67,7 @@ class AddPublicPeerActivityTest {
     }
 
     @Test
+    @AllowFlaky(attempts = 3)
     fun addPublicPeerMissingCertificate() {
         testRule.start()
         clickOn(R.id.addPeer)

--- a/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/PeerActivityTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/PeerActivityTest.kt
@@ -3,12 +3,16 @@ package tech.relaycorp.ping.ui.peers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn
+import com.schibsted.spain.barista.rule.flaky.AllowFlaky
+import com.schibsted.spain.barista.rule.flaky.FlakyTestRule
+import com.schibsted.spain.barista.rule.flaky.Repeat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import tech.relaycorp.ping.R
 import tech.relaycorp.ping.data.database.dao.PublicPeerDao
@@ -21,12 +25,18 @@ import tech.relaycorp.ping.test.WaitAssertions.waitFor
 import tech.relaycorp.ping.ui.peers.PeerActivity
 import javax.inject.Inject
 
+
 @RunWith(AndroidJUnit4::class)
 class PeerActivityTest {
 
     @Rule
     @JvmField
     val testRule = BaseActivityTestRule(PeerActivity::class, false)
+
+    @Rule
+    @JvmField
+    val flakyChainRule = RuleChain.outerRule(FlakyTestRule())
+        .around(testRule)
 
     @Inject
     lateinit var publicPeerDao: PublicPeerDao
@@ -50,6 +60,7 @@ class PeerActivityTest {
     }
 
     @Test
+    @AllowFlaky(attempts = 3)
     fun deletes() {
         val peer = PublicPeerEntityFactory.build()
         runBlocking {

--- a/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/PeersActivityTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/ping/ui/peers/PeersActivityTest.kt
@@ -2,6 +2,7 @@ package tech.relaycorp.ping.ui.peers
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
+import com.schibsted.spain.barista.rule.flaky.AllowFlaky
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -11,6 +12,7 @@ import tech.relaycorp.ping.data.database.dao.PublicPeerDao
 import tech.relaycorp.ping.test.AppTestProvider.component
 import tech.relaycorp.ping.test.BaseActivityTestRule
 import tech.relaycorp.ping.test.PublicPeerEntityFactory
+import tech.relaycorp.ping.test.WaitAssertions.waitFor
 import javax.inject.Inject
 
 @RunWith(AndroidJUnit4::class)
@@ -29,6 +31,7 @@ class PeersActivityTest {
     }
 
     @Test
+    @AllowFlaky(attempts = 3)
     fun showsPublicPeers() {
         val peer = PublicPeerEntityFactory.build()
         runBlocking {
@@ -37,6 +40,8 @@ class PeersActivityTest {
 
         testRule.start()
 
-        assertDisplayed(peer.publicAddress)
+        waitFor {
+            assertDisplayed(peer.publicAddress)
+        }
     }
 }


### PR DESCRIPTION
I haven't been able to make those tests fail after dozens of times. But I've known snackbars and activity lifecycles to be somewhat flaky things to assert.

Our helper testing library has this annotation that attempts a test multiple times, to see if it eventually passes. I know it's not an ideal solution, but it's a way for us to keep those particular checks. Otherwise we'll probably need to re-write the test to assert state in some other way that's not through UI.

Closes #61