### PR TITLE
chore: Remove API 21 device from CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ This app only communicates with the following:
 
 This app doesn't track usage (for example, using Google Analytics), nor does it use ads.
 
-## Development
-
-The project requires [Android Studio](https://developer.android.com/studio/) 4+.
-
 ## Contributing
 
 We love contributions! If you haven't contributed to a Relaycorp project before, please take a minute to [read our guidelines](https://github.com/relaycorp/.github/blob/master/CONTRIBUTING.md) first.

--- a/app/firebase-test-lab.yml
+++ b/app/firebase-test-lab.yml
@@ -4,12 +4,6 @@ spec:
   test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
   timeout: 30m
   device:
-    # Asus Nexus 7 (physical). The oldest device we're testing.
-    - model: flo
-      version: 21   # Android 5.0
-      locale: en
-      orientation: portrait
-
     # Nexus 5X (virtual)
     - model: Nexus5X
       version: 24   # Android 7.0


### PR DESCRIPTION
Addresses https://github.com/relaycorp/relayverse/issues/45

I also removed the mention of the Android Studio version, because those are increasingly hard to track. Let me know if that's ok @gnarea.