### PR TITLE
fix: Improve add public peer label

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="peer_private">Private Endpoint</string>
     <string name="peer_add">Add Endpoint</string>
     <string name="peer_delete_confirm">Are you sure you want to delete this Endpoint?</string>
-    <string name="peer_conn_params_file_label">Connection parameters *</string>
+    <string name="peer_conn_params_file_label">Connection parameters\u00A0*</string>
     <string name="peer_conn_params_file_button">Select file</string>
     <string name="peer_conn_params_file_picked">Connection parameters file picked</string>
     <string name="peer_add_error">Error saving new peer</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -82,7 +82,7 @@
     <!-- Fields / Form -->
 
     <style name="Widget.Ping.Label">
-        <item name="android:layout_width">112dp</item>
+        <item name="android:layout_width">116dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingStart">16dp</item>
         <item name="android:paddingEnd">16dp</item>


### PR DESCRIPTION
Closes https://github.com/relaycorp/awala-ping-android/issues/176

I did 2 things:
- Added a bit more width to the form labels
- Used a non-breaking space so that the * will never get detached from the last word and appear by itself in a single line